### PR TITLE
Add formatter to count the visits and sort them

### DIFF
--- a/lib/formatter.rb
+++ b/lib/formatter.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Format the results into following format
+# [
+#   ['/page1', 5],
+#   ['/page2', 7]...
+# ]
+class Formatter
+  def self.format(results:, unique: false, order: :desc)
+    begin
+      results = if unique
+                  results.map { |page, visits| [page, visits.keys.length] }
+                else
+                  results.map { |page, visits| [page, visits.values.inject(:+)] }
+                end
+    rescue StandardError
+      raise(StandardError, 'File content is in illegal format')
+    end
+
+    sort(results: results, order: order)
+  end
+
+  class << self
+    private
+
+    def sort(results:, order:)
+      results.sort_by do |pair|
+        order == :desc ? -pair[1] : pair[1]
+      end
+    end
+  end
+end

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'formatter'
+
+RSpec.describe Formatter do
+  describe '#format' do
+    let(:results) do
+      {
+        '/contact' => {
+          '180.121.111.010' => 2,
+          '180.122.111.010' => 1
+        },
+        '/help_page/1' => {
+          '121.118.011.018' => 4
+        }
+      }
+    end
+
+    it 'responds to format' do
+      expect(described_class).to respond_to(:format)
+    end
+
+    context 'with invalid data' do
+      let(:invalid_results) do
+        {
+          '/contact' => {
+            '180.121.111.010' => 'invalid',
+            '180.122.111.010' => 1
+          },
+          '/help_page/1' => {
+            '121.118.011.018' => 4
+          }
+        }
+      end
+      let(:subject) { described_class.format(results: invalid_results) }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(StandardError, 'File content is in illegal format')
+      end
+    end
+
+    context 'with valid data and unique as false' do
+      let(:subject) { described_class.format(results: results) }
+
+      it 'return all visits' do
+        expect(subject).to eq(
+          [
+            ['/help_page/1', 4],
+            ['/contact', 3]
+          ]
+        )
+      end
+    end
+
+    context 'with valid data and unique as true' do
+      let(:subject) { described_class.format(results: results, unique: true) }
+
+      it 'return unique visits' do
+        expect(subject).to eq(
+          [
+            ['/contact', 2],
+            ['/help_page/1', 1]
+          ]
+        )
+      end
+    end
+
+    context 'with valid data and order as :asc' do
+      subject { described_class.format(results: results, order: :asc) }
+
+      it 'returns all visits in ascending order' do
+        expect(subject).to eq(
+          [
+            ['/contact', 3],
+            ['/help_page/1', 4]
+          ]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added formatter to count visits

- This calculates the total visits and unique visits based on the "unique" param. By default, the value is `false`
- This sorts the results based on the "order" param. By default, the value is `:desc`